### PR TITLE
Allow prompt to be configurable

### DIFF
--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.keycloak.extensions</groupId>
         <artifactId>keycloak-discord-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1</version>
     </parent>
 
     <name>Keycloak Discord EAR</name>

--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.keycloak.extensions</groupId>
         <artifactId>keycloak-discord-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1</version>
     </parent>
 
     <name>Keycloak Discord EJB</name>

--- a/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProviderConfig.java
+++ b/ejb/src/main/java/org/keycloak/social/discord/DiscordIdentityProviderConfig.java
@@ -54,4 +54,8 @@ public class DiscordIdentityProviderConfig extends OAuth2IdentityProviderConfig 
         }
         return Collections.emptySet();
     }
+
+    public void setPrompt(String prompt) {
+        getConfig().put("prompt", prompt);
+    }
 }

--- a/ejb/src/main/resources/theme/discord/admin/resources/partials/realm-identity-provider-discord.html
+++ b/ejb/src/main/resources/theme/discord/admin/resources/partials/realm-identity-provider-discord.html
@@ -114,6 +114,22 @@
                 </div>
                 <kc-tooltip>{{:: 'post-broker-login-flow.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="prompt">{{:: 'prompt' | translate}}</label>
+                <div class="col-md-6">
+                    <div>
+                        <select class="form-control" id="prompt" ng-model="identityProvider.config.prompt">
+                            <option value="">{{:: 'unspecified.option' | translate}}</option>
+                            <option value="none">{{:: 'none.option' | translate}}</option>
+                            <option value="consent">{{:: 'consent.option' | translate}}</option>
+                            <option value="login">{{:: 'login.option' | translate}}</option>
+                            <option value="select_account">{{:: 'select-account.option' | translate}}</option>
+                        </select>
+                    </div>
+                </div>
+                <kc-tooltip>{{:: 'prompt.tooltip' | translate}}</kc-tooltip>
+            </div>
+
         </fieldset>
 
         <div class="form-group">

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.keycloak.extensions</groupId>
     <artifactId>keycloak-discord-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
The default for prompt value results in users needing to re-consent to the discord app permissions with each login. These changes allow the prompt value to be configured through the keycloak admin ui.

If prompt is set to `none` the user will not need to consent to permissions with each login.
![Screenshot from 2019-11-15 17-41-21](https://user-images.githubusercontent.com/13265645/68980679-2ba3c800-07cf-11ea-88e7-3ba01df39980.png)

Also bumped the version!