### PR TITLE
fix: update authorization URL

### DIFF
--- a/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
@@ -41,7 +41,7 @@ public class DiscordIdentityProvider extends AbstractOAuth2IdentityProvider<Disc
 
     private static final Logger log = Logger.getLogger(DiscordIdentityProvider.class);
 
-    public static final String AUTH_URL = "https://discord.com/api/oauth2/authorize";
+    public static final String AUTH_URL = "https://discord.com/oauth2/authorize";
     public static final String TOKEN_URL = "https://discord.com/api/oauth2/token";
     public static final String PROFILE_URL = "https://discord.com/api/users/@me";
     public static final String GROUP_URL = "https://discord.com/api/users/@me/guilds";


### PR DESCRIPTION
Fixed a URL according to: 
https://discord.com/developers/docs/topics/oauth2
Trying to login with old version will redirect to bare-bones JSON output and not the actual login/consent page for Discord.