### PR TITLE
Conditionally append discriminator if not 0

### DIFF
--- a/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
@@ -69,7 +69,14 @@ public class DiscordIdentityProvider extends AbstractOAuth2IdentityProvider<Disc
     protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
         BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "id"));
 
-        user.setUsername(getJsonProperty(profile, "username") + "#" + getJsonProperty(profile, "discriminator"));
+        String username = getJsonProperty(profile, "username");
+        String discriminator = getJsonProperty(profile, "discriminator");
+
+        if (!"0".equals(discriminator)) {
+            username += "#" + discriminator;
+        }
+
+        user.setUsername(username);
         user.setEmail(getJsonProperty(profile, "email"));
         user.setIdpConfig(getConfig());
         user.setIdp(this);


### PR DESCRIPTION
With unique usernames rolling out, usernames will no longer have a discriminator. During the migration user will have a '#0' discriminator after updating. This change will conditionally append the username given to Keycloak if the discriminator is not 0.

https://support-dev.discord.com/hc/en-us/articles/13667755828631-Updating-Apps-to-Support-Unique-Usernames#h_01GYA87X9QZ19H2X6PJ3M35ZDH